### PR TITLE
Add label values to the runtimes. Add groupId and artifactId to runtimes

### DIFF
--- a/Parser.java
+++ b/Parser.java
@@ -251,6 +251,8 @@ public class Parser {
     public static class Runtime {
 
         private String name;
+        private String groupId;
+        private String artifactId;
         private String version;
         private String url;
         private RuntimeType type;
@@ -268,6 +270,22 @@ public class Parser {
 
         public void setName(String name) {
             this.name = name;
+        }
+
+        public String getGroupId() {
+            return groupId;
+        }
+
+        public void setGroupId(final String groupId) {
+            this.groupId = groupId;
+        }
+
+        public String getArtifactId() {
+            return artifactId;
+        }
+
+        public void setArtifactId(final String artifactId) {
+            this.artifactId = artifactId;
         }
 
         public String getVersion() {

--- a/stacks.yaml
+++ b/stacks.yaml
@@ -380,6 +380,8 @@ availableRuntimes:
 
  - &jboss-as711runtime
    name: JBoss AS 7.1.1 (Brontes)
+   groupId: org.jboss.as
+   artifactId: jboss-as-dist
    version: 7.1.1.Final
    type: AS
    url: http://download.jboss.org/jbossas/7.1/jboss-as-7.1.1.Final/jboss-as-7.1.1.Final.zip
@@ -400,13 +402,15 @@ availableRuntimes:
     - *richfaces-archetype-kitchensink-422final2
     - *jboss-errai-kitchensink-archetype-202final
    labels: 
-    -
+    - requiresLogModule: false
 
    ###############
 
  - &jboss-as710runtime
    name: JBoss AS 7.1.0 (Thunder)
-   version: 7.1.0
+   groupId: org.jboss.as
+   artifactId: jboss-as-dist
+   version: 7.1.0.Final
    type: AS
    url: http://download.jboss.org/jbossas/7.1/jboss-as-7.1.0.Final/jboss-as-7.1.0.Final.zip
    boms:
@@ -426,7 +430,7 @@ availableRuntimes:
     - *richfaces-archetype-kitchensink-422final2
     - *jboss-errai-kitchensink-archetype-202final
    labels: 
-    -
+    - requiresLogModule: false
  
    ###############
    #   A S 7.0   #
@@ -434,6 +438,8 @@ availableRuntimes:
  
  - &jboss-as702runtime-web
    name: JBoss AS 7.0.2 (Arc) - Web Profile
+   groupId: org.jboss.as
+   artifactId: jboss-as-dist
    version: 7.0.2.Final
    type: AS
    url: http://download.jboss.org/jbossas/7.0/jboss-as-7.0.2.Final/jboss-as-web-7.0.2.Final.zip
@@ -447,12 +453,14 @@ availableRuntimes:
     - *jboss-javaee6-webapp-ear-archetype-702cr2
     - *jboss-javaee6-webapp-ear-archetype-blank-702cr2
    labels: 
-    -
+    - requiresLogModule: true
     
    #################
    
  - &jboss-as702runtime-full
    name: JBoss AS 7.0.2 (Arc) - Full Profile
+   groupId: org.jboss.as
+   artifactId: jboss-as-dist
    version: 7.0.2.Final
    type: AS
    url: http://download.jboss.org/jbossas/7.0/jboss-as-7.0.2.Final/jboss-as-7.0.2.Final.zip
@@ -466,7 +474,7 @@ availableRuntimes:
     - *jboss-javaee6-webapp-ear-archetype-702cr2
     - *jboss-javaee6-webapp-ear-archetype-blank-702cr2
    labels: 
-    -
+    - requiresLogModule: true
         
 ##########################################################
 #                                                        #
@@ -524,4 +532,4 @@ majorReleases:
    version: 6
    recommendedRuntime: *jbosseap6runtime
    minorReleases:
-    - *jbeap60    
+    - *jbeap60


### PR DESCRIPTION
Not sure if adding the groupId and artifactId to the runtimes is acceptable, but it will help with maven plugins or plugins that use maven. It allows for dependency management like aether, which both Forge and the Maven plugin use, to resolve the dependency locally if it exists.

The labels added are for use when launching AS.
