### PR TITLE
Aerogear 1.0.0.M8 release

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -402,7 +402,7 @@ artifacts:
  - name: jboss-as-kitchensink-html5-mobile
    useCases: 
     - Uses JSF 2.0, CDI 1.0, EJB 3.1, JPA 2.0 and Bean Validation 1.0.
-   archetype: *jboss-html5-mobile-archetype-100m7a
+   archetype: *jboss-html5-mobile-archetype-100m8
    bom:
     - *jboss-javaee-6_0-web-300
    targetRuntimes:

--- a/stacks.yaml
+++ b/stacks.yaml
@@ -461,7 +461,7 @@ availableArchetypes:
    description: An archetype that generates a Java EE 6 application using HTML5, and JAX-RS to support both desktop and mobile web browsers
    groupId: org.jboss.aerogear.archetypes
    artifactId: jboss-html5-mobile-archetype
-   recommendedVersion: 1.0.0.M7a
+   recommendedVersion: 1.0.0.M8
    repositoryURL: 
 
    ############################
@@ -560,10 +560,10 @@ availableArchetypeVersions:
    #   Java EE 6 HTML5 Mobile Web Application    #
    ###############################################
    
- - &jboss-html5-mobile-archetype-100m7a
-   id: jboss-html5-mobile-archetype-100m7a
+ - &jboss-html5-mobile-archetype-100m8
+   id: jboss-html5-mobile-archetype-100m8
    archetype: *jboss-html5-mobile-archetype
-   version: 1.0.0.M7a
+   version: 1.0.0.M8
    repositoryURL: 
    labels: {}
    
@@ -620,7 +620,7 @@ availableRuntimes:
     - *jboss-javaee6-webapp-blank-archetype-712cr1
     - *jboss-javaee6-webapp-ear-archetype-712cr1
     - *jboss-javaee6-webapp-ear-blank-archetype-712cr1
-    - *jboss-html5-mobile-archetype-100m7a
+    - *jboss-html5-mobile-archetype-100m8
     - *richfaces-archetype-kitchensink-423final2
     - *jboss-errai-kitchensink-archetype-211final
    labels: {
@@ -663,7 +663,7 @@ availableRuntimes:
     - *jboss-javaee6-webapp-blank-archetype-712cr1
     - *jboss-javaee6-webapp-ear-archetype-712cr1
     - *jboss-javaee6-webapp-ear-blank-archetype-712cr1
-    - *jboss-html5-mobile-archetype-100m7a
+    - *jboss-html5-mobile-archetype-100m8
     - *richfaces-archetype-kitchensink-423final2
     - *jboss-errai-kitchensink-archetype-211final
    labels: {
@@ -703,7 +703,7 @@ availableRuntimes:
     - *jboss-javaee6-webapp-blank-archetype-712cr1
     - *jboss-javaee6-webapp-ear-archetype-712cr1
     - *jboss-javaee6-webapp-ear-blank-archetype-712cr1
-    - *jboss-html5-mobile-archetype-100m7a
+    - *jboss-html5-mobile-archetype-100m8
     - *richfaces-archetype-kitchensink-423final2
     - *jboss-errai-kitchensink-archetype-211final
    labels: {


### PR DESCRIPTION
We've just released our M8 release,  

There is also a jira https://issues.jboss.org/browse/JDF-188, to pull in the latest tag of the quickstarts
