### PR TITLE
JDF-222 - Stacks should permit a "Early Access" Runtimes

### DIFF
--- a/src/test/resources/settings-centralonly.xml
+++ b/src/test/resources/settings-centralonly.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   JBoss, Home of Professional Open Source
+   Copyright <Year>, Red Hat, Inc. and/or its affiliates, and individual
+   contributors by the @authors tag. See the copyright.txt in the 
+   distribution for a full listing of individual contributors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,  
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <profiles>
+
+    </profiles>
+
+    <activeProfiles>
+    </activeProfiles>
+</settings>

--- a/src/test/resources/settings-eap610alpha.xml
+++ b/src/test/resources/settings-eap610alpha.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   JBoss, Home of Professional Open Source
+   Copyright <Year>, Red Hat, Inc. and/or its affiliates, and individual
+   contributors by the @authors tag. See the copyright.txt in the 
+   distribution for a full listing of individual contributors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,  
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <profiles>
+   
+    <!-- Configure the JBoss EAP Maven repository -->
+        <profile>
+            <id>jboss-repositories</id>
+            <repositories>
+                <repository>
+                    <id>jboss-eap-610alpha</id>
+                    <url>http://maven.repository.redhat.com/techpreview/eap6/6.1.0.Alpha1/maven-repository/</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>jboss-eap-601-maven-plugin-repository</id>
+                    <url>http://maven.repository.redhat.com/techpreview/eap6/6.1.0.Alpha1/maven-repository/</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+
+    <activeProfiles>
+        <activeProfile>jboss-repositories</activeProfile>
+    </activeProfiles>
+
+</settings>

--- a/stacks.yaml
+++ b/stacks.yaml
@@ -20,9 +20,16 @@
 
 licenses:
  - &lgpl http://www.gnu.org/copyleft/lesser.txt
+#metadatas
  - &lastArchetypeRelease 7.1.3.CR3
  - &lastJDFBomRelease 1.0.4.Final
  - &lastSpecBomRelease 3.0.2.Final
+ - &eap600SpecBomRelease 3.0.0.Final-redhat-1
+ - &eap601SpecBomRelease 3.0.1.Final-redhat-1
+ - &eap610SpecBomRelease 3.0.2.Final-redhat-1
+ - &wfk21BomRelease 1.0.1.Final-redhat-1
+ - &eap601BomRelease 1.0.2.Final-redhat-1
+ - &eap610BomRelease 1.0.4.Final-redhat-1
  
 #################################################################
 #                                                               #
@@ -105,7 +112,7 @@ availableBoms:
    description: Errai provides a comprehensive framework and tools for building rich web applications, leveraging the GWT compiler. With standard server-side APIs, such as CDI, in the browser, managing large web applications was never so easy. This BOM adds both Errai and GWT to your project.
    groupId: com.redhat.jboss.wfk.boms
    artifactId: jboss-javaee-6.0-with-errai
-   recommendedVersion: 1.0.1.Final-redhat-1
+   recommendedVersion: *wfk21BomRelease
    ##############################
 
  - &jboss-javaee-6_0-with-hibernate
@@ -122,7 +129,7 @@ availableBoms:
    description: Historically, Hibernate facilitated the storage and retrieval of Java domain objects via Object/Relational Mapping. Today, Hibernate is a collection of related projects enabling developers to utilize POJO-style domain models in their applications in ways extending well beyond Object/Relational Mapping. This BOM builds on the Java EE full profile BOM, adding Hibernate Community projects including Hibernate ORM, Hibernate Search and Hibernate Validator. It also provides tool projects such as Hibernate JPA Model Gen and Hibernate Validator Annotation Processor.
    groupId: com.redhat.jboss.wfk.boms
    artifactId: jboss-javaee-6.0-with-hibernate
-   recommendedVersion: 1.0.1.Final-redhat-1
+   recommendedVersion: *wfk21BomRelease
    ###################################
    
  - &jboss-javaee-6_0-with-hibernate3
@@ -139,7 +146,7 @@ availableBoms:
    description: Dependency Management for Java EE 6 Specification APIs with Hibernate 3 projects.
    groupId: com.redhat.jboss.wfk.boms
    artifactId: jboss-javaee-6.0-with-hibernate3
-   recommendedVersion: 1.0.1.Final-redhat-1
+   recommendedVersion: *wfk21BomRelease
    
    ####################################
    
@@ -157,7 +164,7 @@ availableBoms:
    description: Dependency Management for Java EE 6 Specification APIs with Infinispan
    groupId: com.redhat.jboss.wfk.boms
    artifactId: jboss-javaee-6.0-with-infinispan
-   recommendedVersion: 1.0.1.Final-redhat-1
+   recommendedVersion: *wfk21BomRelease
    
    ####################################
    
@@ -175,7 +182,7 @@ availableBoms:
    description: Dependency Management for Java EE 6 Specification APIs with Logging Tools
    groupId: com.redhat.jboss.wfk.boms
    artifactId: jboss-javaee-6.0-with-logging
-   recommendedVersion: 1.0.1.Final-redhat-1
+   recommendedVersion: *wfk21BomRelease
    
    ###################################
    
@@ -193,7 +200,7 @@ availableBoms:
    description: Dependency Management for Java EE 6 Specification APIs with OSGI.
    groupId: com.redhat.jboss.wfk.boms
    artifactId: jboss-javaee-6.0-with-osgi
-   recommendedVersion: 1.0.1.Final-redhat-1
+   recommendedVersion: *wfk21BomRelease
    
    ####################################
 
@@ -221,7 +228,7 @@ availableBoms:
    description: Dependency Management for Java EE 6 Specification APIs with Richfaces.
    groupId: com.redhat.jboss.wfk.boms
    artifactId: jboss-javaee-6.0-with-richfaces
-   recommendedVersion: 1.0.1.Final-redhat-1
+   recommendedVersion: *wfk21BomRelease
       
    ##################################
    
@@ -239,7 +246,7 @@ availableBoms:
    description: Dependency Management for Java EE 6 Specification APIs with JBoss specific Security features. Currently included is JBoss Negotiation.
    groupId: com.redhat.jboss.wfk.boms
    artifactId: jboss-javaee-6.0-with-security
-   recommendedVersion: 1.0.1.Final-redhat-1
+   recommendedVersion: *wfk21BomRelease
          
    ###############################
    
@@ -257,7 +264,7 @@ availableBoms:
    description: Java EE lacks any testing APIs, and for this reason JBoss developed the Arquillian project, along with its various component projects, such as Arquillian Drone, and the sister project Shrinkwrap. This BOM builds on the Java EE full profile BOM, adding Arquillian to the mix. It also provides a version of JUnit and TestNG recommended for use with Arquillian. Furthermore, this BOM adds the JBoss AS Maven deployment plugin. EAP 6s recommended mode of deployment is via the management APIs, and the Maven plugin is the recommended way to do this, if the customer is using Maven for building.
    groupId: com.redhat.jboss.wfk.boms
    artifactId: jboss-javaee-6.0-with-tools
-   recommendedVersion: 1.0.1.Final-redhat-1
+   recommendedVersion: *wfk21BomRelease
        
    ################################
  
@@ -275,7 +282,7 @@ availableBoms:
    description: JBoss AS includes a world class transaction manager. In order to access its full capabilites, including for example XTS, WS-AT and WS-BA, you need to use the JBossTS APIs. This BOM adds the JBossTS APIs to the stack.
    groupId: com.redhat.jboss.wfk.boms
    artifactId: jboss-javaee-6.0-with-transactions
-   recommendedVersion: 1.0.1.Final-redhat-1
+   recommendedVersion: *wfk21BomRelease
    
    #########################
    #   W F K    B O M S    #
@@ -323,10 +330,10 @@ availableBomVersions:
    version: *lastSpecBomRelease
    labels: {}
    
- - &jboss-javaee-6_0-all-301redhat1
-   id: jboss-javaee-6_0-all-301redhat1
+ - &jboss-javaee-6_0-all-eap601
+   id: jboss-javaee-6_0-all-eap601
    bom: *jboss-javaee-6_0-all
-   version: 3.0.1.Final-redhat-1
+   version: *eap601SpecBomRelease
    labels: {
        EAP601RepositoryRequired: true,     
    }
@@ -349,12 +356,21 @@ availableBomVersions:
        EAP600RepositoryRequired: true,
    }
    
- - &jboss-javaee-6_0-web-301redhat1 
-   id: jboss-javaee-6_0-web-301redhat1
+ - &jboss-javaee-6_0-web-eap601 
+   id: jboss-javaee-6_0-web-eap601
    bom: *jboss-javaee-6_0-web
-   version: 3.0.1.Final-redhat-1
+   version: *eap601SpecBomRelease
    labels: {
        EAP601RepositoryRequired: true,
+   }
+
+ - &jboss-javaee-6_0-web-eap61
+   id: jboss-javaee-6_0-web-eap61
+   bom: *jboss-javaee-6_0-web
+   version: *eap610SpecBomRelease
+   labels: {
+       EAP610AlphaRepositoryRequired: true,
+       EarlyAccess: true,
    }
    
    #################
@@ -375,13 +391,23 @@ availableBomVersions:
        EAP600RepositoryRequired: true,
    }
    
- - &jboss-javaee-6_0-301redhat1
-   id: jboss-javaee-6_0-301redhat1
+ - &jboss-javaee-6_0-eap601
+   id: jboss-javaee-6_0-eap601
    bom: *jboss-javaee-6_0
-   version: 3.0.1.Final-redhat-1
+   version: *eap601SpecBomRelease
    labels: {
        EAP601RepositoryRequired: true,
    }
+   
+ - &jboss-javaee-6_0-eap61
+   id: jboss-javaee-6_0-eap61
+   bom: *jboss-javaee-6_0
+   version: *eap610SpecBomRelease
+   labels: {
+       EAP610AlphaRepositoryRequired: true,
+       EarlyAccess: true,
+   }
+   
 
    ###################################
    #       Java EE 6 with All        #
@@ -392,6 +418,16 @@ availableBomVersions:
    bom: *jboss-javaee-6_0-with-all
    version: *lastJDFBomRelease
    labels: {}
+   
+ - &jboss-javaee-6_0-with-all-eap61
+   id: jboss-javaee-6_0-with-all-eap61
+   bom: *jboss-javaee-6_0-with-all
+   version: *eap610BomRelease
+   labels: {
+       EAP610AlphaRepositoryRequired: true,
+       EarlyAccess: true,
+   }
+
 
    ###################################
    #   Java EE 6 with Deltaspike     #
@@ -402,6 +438,15 @@ availableBomVersions:
    bom: *jboss-javaee-6_0-with-deltaspike
    version: *lastJDFBomRelease
    labels: {}
+   
+ - &jboss-javaee-6_0-with-deltaspike-eap61
+   id: jboss-javaee-6_0-with-deltaspike-eap61
+   bom: *jboss-javaee-6_0-with-deltaspike
+   version: *eap610BomRelease
+   labels: {
+       EAP610AlphaRepositoryRequired: true,
+       EarlyAccess: true,
+   }   
    
    ###################################
    #   Java EE 6 with Errai and GWT  #
@@ -421,21 +466,31 @@ availableBomVersions:
       EAP600RepositoryRequired: true,
    }
    
- - &jboss-javaee-6_0-with-errai-102-redhat1
-   id: jboss-javaee-6_0-with-errai-102-redhat1
+ - &jboss-javaee-6_0-with-errai-eap601
+   id: jboss-javaee-6_0-with-errai-eap601
    bom: *jboss-javaee-6_0-with-errai
-   version: 1.0.2.Final-redhat-1
+   version: *eap601BomRelease
    labels: {
       EAP601RepositoryRequired: true,
    }
-   
- - &jboss-javaee-6_0-with-errai-wfk-101-redhat1
-   id: jboss-javaee-6_0-with-errai-wfk-101-redhat1
+
+ - &jboss-javaee-6_0-with-errai-eap61
+   id: jboss-javaee-6_0-with-errai-eap61
+   bom: *jboss-javaee-6_0-with-errai
+   version: *eap610BomRelease
+   labels: {
+       EAP610AlphaRepositoryRequired: true,
+       EarlyAccess: true,
+   }   
+
+ - &jboss-javaee-6_0-with-errai-wfk-21
+   id: jboss-javaee-6_0-with-errai-wfk-21
    bom: *jboss-javaee-6_0-with-errai-wfk
-   version: 1.0.1.Final-redhat-1
+   version: *wfk21BomRelease
    labels: {
       WFK21RepositoryRequired: true,
-   }    
+   }
+   
    
    ##################################
    #   Java EE 6 with Hibernate     #
@@ -462,20 +517,28 @@ availableBomVersions:
    labels: {
       EAP600RepositoryRequired: true,
    }
-
    
- - &jboss-javaee-6_0-with-hibernate-102-redhat1
-   id: jboss-javaee-6_0-with-hibernate-102-redhat1
+ - &jboss-javaee-6_0-with-hibernate-eap601
+   id: jboss-javaee-6_0-with-hibernate-eap601
    bom: *jboss-javaee-6_0-with-hibernate
-   version: 1.0.2.Final-redhat-1
+   version: *eap601BomRelease
    labels: {
       EAP601RepositoryRequired: true,
    }
+
+ - &jboss-javaee-6_0-with-hibernate-eap61
+   id: jboss-javaee-6_0-with-hibernate-eap61
+   bom: *jboss-javaee-6_0-with-hibernate
+   version: *eap610BomRelease
+   labels: {
+       EAP610AlphaRepositoryRequired: true,
+       EarlyAccess: true,
+   }   
    
- - &jboss-javaee-6_0-with-hibernate-wfk-101-redhat1
-   id: jboss-javaee-6_0-with-hibernate-wfk-101-redhat1
+ - &jboss-javaee-6_0-with-hibernate-wfk-21
+   id: jboss-javaee-6_0-with-hibernate-wfk-21
    bom: *jboss-javaee-6_0-with-hibernate-wfk
-   version: 1.0.1.Final-redhat-1
+   version: *wfk21BomRelease
    labels: {
       WFK21RepositoryRequired: true,
    }   
@@ -490,18 +553,28 @@ availableBomVersions:
    version: *lastJDFBomRelease
    labels: {}
 
- - &jboss-javaee-6_0-with-hibernate3-102-redhat1
-   id: jboss-javaee-6_0-with-hibernate3-102-redhat1
+ - &jboss-javaee-6_0-with-hibernate3-eap601
+   id: jboss-javaee-6_0-with-hibernate3-eap601
    bom: *jboss-javaee-6_0-with-hibernate3
-   version: 1.0.2.Final-redhat-1
+   version: *eap601BomRelease
    labels: {
       EAP601RepositoryRequired: true,
    }
    
- - &jboss-javaee-6_0-with-hibernate3-wfk-101-redhat1
-   id: jboss-javaee-6_0-with-hibernate3-wfk-101-redhat1
+ - &jboss-javaee-6_0-with-hibernate3-eap61
+   id: jboss-javaee-6_0-with-hibernate3-eap61
+   bom: *jboss-javaee-6_0-with-hibernate3
+   version: *eap610BomRelease
+   labels: {
+       EAP610AlphaRepositoryRequired: true,
+       EarlyAccess: true,
+   }   
+
+   
+ - &jboss-javaee-6_0-with-hibernate3-wfk-21
+   id: jboss-javaee-6_0-with-hibernate3-wfk-21
    bom: *jboss-javaee-6_0-with-hibernate3-wfk
-   version: 1.0.1.Final-redhat-1
+   version: *wfk21BomRelease
    labels: {
       WFK21RepositoryRequired: true,
    }   
@@ -516,10 +589,19 @@ availableBomVersions:
    version: *lastJDFBomRelease
    labels: {}
 
- - &jboss-javaee-6_0-with-infinispan-wfk-101-redhat1
-   id: jboss-javaee-6_0-with-infinispan-wfk-101-redhat1
+ - &jboss-javaee-6_0-with-infinispan-eap61
+   id: jboss-javaee-6_0-with-infinispan-eap61
+   bom: *jboss-javaee-6_0-with-infinispan
+   version: *eap610BomRelease
+   labels: {
+       EAP610AlphaRepositoryRequired: true,
+       EarlyAccess: true,
+   }   
+
+ - &jboss-javaee-6_0-with-infinispan-wfk-21
+   id: jboss-javaee-6_0-with-infinispan-wfk-21
    bom: *jboss-javaee-6_0-with-infinispan-wfk
-   version: 1.0.1.Final-redhat-1
+   version: *wfk21BomRelease
    labels: {
       WFK21RepositoryRequired: true,
    }   
@@ -534,18 +616,27 @@ availableBomVersions:
    version: *lastJDFBomRelease
    labels: {}   
 
- - &jboss-javaee-6_0-with-logging-102-redhat1
-   id: jboss-javaee-6_0-with-logging-102-redhat1
+ - &jboss-javaee-6_0-with-logging-eap601
+   id: jboss-javaee-6_0-with-logging-eap601
    bom: *jboss-javaee-6_0-with-logging
-   version: 1.0.2.Final-redhat-1
+   version: *eap601BomRelease
    labels: {
       EAP601RepositoryRequired: true,
    }
 
- - &jboss-javaee-6_0-with-logging-wfk-101-redhat1
-   id: jboss-javaee-6_0-with-logging-wfk-101-redhat1
+ - &jboss-javaee-6_0-with-logging-eap61
+   id: jboss-javaee-6_0-with-logging-eap61
+   bom: *jboss-javaee-6_0-with-logging
+   version: *eap610BomRelease
+   labels: {
+       EAP610AlphaRepositoryRequired: true,
+       EarlyAccess: true,
+   }   
+
+ - &jboss-javaee-6_0-with-logging-wfk-21
+   id: jboss-javaee-6_0-with-logging-wfk-21
    bom: *jboss-javaee-6_0-with-logging-wfk
-   version: 1.0.1.Final-redhat-1
+   version: *wfk21BomRelease
    labels: {
       WFK21RepositoryRequired: true,
    }
@@ -560,18 +651,27 @@ availableBomVersions:
    version: *lastJDFBomRelease
    labels: {}
 
- - &jboss-javaee-6_0-with-osgi-102-redhat1
-   id: jboss-javaee-6_0-with-osgi-102-redhat1
+ - &jboss-javaee-6_0-with-osgi-eap601
+   id: jboss-javaee-6_0-with-osgi-eap601
    bom: *jboss-javaee-6_0-with-osgi
-   version: 1.0.2.Final-redhat-1
+   version: *eap601BomRelease
    labels: {
       EAP601RepositoryRequired: true,
    }
-   
- - &jboss-javaee-6_0-with-osgi-wfk-101-redhat1
-   id: jboss-javaee-6_0-with-osgi-wfk-101-redhat1
+
+ - &jboss-javaee-6_0-with-osgi-eap61
+   id: jboss-javaee-6_0-with-osgi-eap61
+   bom: *jboss-javaee-6_0-with-osgi
+   version: *eap610BomRelease
+   labels: {
+       EAP610AlphaRepositoryRequired: true,
+       EarlyAccess: true,
+   }   
+
+ - &jboss-javaee-6_0-with-osgi-wfk-21
+   id: jboss-javaee-6_0-with-osgi-wfk-21
    bom: *jboss-javaee-6_0-with-osgi-wfk
-   version: 1.0.1.Final-redhat-1
+   version: *wfk21BomRelease
    labels: {
       WFK21RepositoryRequired: true,
    }   
@@ -585,6 +685,15 @@ availableBomVersions:
    bom: *jboss-javaee-6_0-with-resteasy
    version: *lastJDFBomRelease
    labels: {}
+
+ - &jboss-javaee-6_0-with-resteasy-eap61
+   id: jboss-javaee-6_0-with-resteasy-eap61
+   bom: *jboss-javaee-6_0-with-resteasy
+   version: *eap610BomRelease
+   labels: {
+       EAP610AlphaRepositoryRequired: true,
+       EarlyAccess: true,
+   }   
       
    ########################################################
    #   JBoss Java EE 6 Specification APIs with Richfaces  #
@@ -595,11 +704,20 @@ availableBomVersions:
    bom: *jboss-javaee-6_0-with-richfaces
    version: *lastJDFBomRelease
    labels: {}
-   
- - &jboss-javaee-6_0-with-richfaces-wfk-101-redhat1
-   id: jboss-javaee-6_0-with-richfaces-wfk-101-redhat1
+
+ - &jboss-javaee-6_0-with-richfaces-eap61
+   id: jboss-javaee-6_0-with-richfaces-eap61
+   bom: *jboss-javaee-6_0-with-richfaces
+   version: *eap610BomRelease
+   labels: {
+       EAP610AlphaRepositoryRequired: true,
+       EarlyAccess: true,
+   }   
+
+ - &jboss-javaee-6_0-with-richfaces-wfk-21
+   id: jboss-javaee-6_0-with-richfaces-wfk-21
    bom: *jboss-javaee-6_0-with-richfaces-wfk
-   version: 1.0.1.Final-redhat-1
+   version: *wfk21BomRelease
    labels: {
       WFK21RepositoryRequired: true,
    }   
@@ -615,18 +733,27 @@ availableBomVersions:
    version: *lastJDFBomRelease
    labels: {}
 
- - &jboss-javaee-6_0-with-security-102-redhat1
-   id: jboss-javaee-6_0-with-security-102-redhat1
+ - &jboss-javaee-6_0-with-security-eap601
+   id: jboss-javaee-6_0-with-security-eap601
    bom: *jboss-javaee-6_0-with-security
-   version: 1.0.2.Final-redhat-1
+   version: *eap601BomRelease
    labels: {
       EAP601RepositoryRequired: true,
    }
+
+ - &jboss-javaee-6_0-with-security-eap61
+   id: jboss-javaee-6_0-with-security-eap61
+   bom: *jboss-javaee-6_0-with-security
+   version: *eap610BomRelease
+   labels: {
+       EAP610AlphaRepositoryRequired: true,
+       EarlyAccess: true,
+   }   
       
- - &jboss-javaee-6_0-with-security-wfk-101-redhat1
-   id: jboss-javaee-6_0-with-security-wfk-101-redhat1
+ - &jboss-javaee-6_0-with-security-wfk-21
+   id: jboss-javaee-6_0-with-security-wfk-21
    bom: *jboss-javaee-6_0-with-security-wfk
-   version: 1.0.1.Final-redhat-1
+   version: *wfk21BomRelease
    labels: {
       WFK21RepositoryRequired: true,
    }
@@ -661,19 +788,29 @@ availableBomVersions:
         EAP600RepositoryRequired: true,
    }    
    
- - &jboss-javaee-6_0-with-tools-102-redhat1
-   id: jboss-javaee-6_0-with-tools-102-redhat1
+ - &jboss-javaee-6_0-with-tools-eap601
+   id: jboss-javaee-6_0-with-tools-eap601
    bom: *jboss-javaee-6_0-with-tools
-   version: 1.0.2.Final-redhat-1
+   version: *eap601BomRelease
    labels: {
         jbossASPluginVersion: 7.3.Final,
         EAP601RepositoryRequired: true,
    }    
+
+ - &jboss-javaee-6_0-with-tools-eap61
+   id: jboss-javaee-6_0-with-tools-eap61
+   bom: *jboss-javaee-6_0-with-tools
+   version: *eap610BomRelease
+   labels: {
+       jbossASPluginVersion: 7.3.Final,
+       EAP610AlphaRepositoryRequired: true,
+       EarlyAccess: true,
+   }   
    
- - &jboss-javaee-6_0-with-tools-wfk-101-redhat1
-   id: jboss-javaee-6_0-with-tools-wfk-101-redhat1
+ - &jboss-javaee-6_0-with-tools-wfk-21
+   id: jboss-javaee-6_0-with-tools-wfk-21
    bom: *jboss-javaee-6_0-with-tools-wfk
-   version: 1.0.1.Final-redhat-1
+   version: *wfk21BomRelease
    labels: {
         jbossASPluginVersion: 7.3.Final,
         WFK21RepositoryRequired: true,
@@ -706,18 +843,27 @@ availableBomVersions:
       EAP600RepositoryRequired: true,
    }
 
- - &jboss-javaee-6_0-with-transactions-102-redhat1
-   id: jboss-javaee-6_0-with-transactions-102-redhat1
+ - &jboss-javaee-6_0-with-transactions-eap601
+   id: jboss-javaee-6_0-with-transactions-eap601
    bom: *jboss-javaee-6_0-with-transactions
-   version: 1.0.2.Final-redhat-1
+   version: *eap601BomRelease
    labels: {
       EAP601RepositoryRequired: true,
    }
+
+ - &jboss-javaee-6_0-with-transactions-eap61
+   id: jboss-javaee-6_0-with-transactions-eap61
+   bom: *jboss-javaee-6_0-with-transactions
+   version: *eap610BomRelease
+   labels: {
+       EAP610AlphaRepositoryRequired: true,
+       EarlyAccess: true,
+   }   
    
- - &jboss-javaee-6_0-with-transactions-wfk-101-redhat1
-   id: jboss-javaee-6_0-with-transactions-wfk-101-redhat1
+ - &jboss-javaee-6_0-with-transactions-wfk-21
+   id: jboss-javaee-6_0-with-transactions-wfk-21
    bom: *jboss-javaee-6_0-with-transactions-wfk
-   version: 1.0.1.Final-redhat-1
+   version: *wfk21BomRelease
    labels: {
       WFK21RepositoryRequired: true,
    }   
@@ -726,28 +872,28 @@ availableBomVersions:
    #    W F K   Spring BOMs     #
    ##############################
    
- - &spring-2_5-bom-wfk-210-redhat1
-   id: spring-2_5-bom-wfk-210-redhat1
+ - &spring-2_5-bom-wfk-21
+   id: spring-2_5-bom-wfk-21
    bom: *spring-2_5-bom-wfk
    version: 2.1.0-redhat-1
    labels: {
-      EAP6RepositoryRequired: true,
+      WFK21RepositoryRequired: true,
    }
    
- - &spring-3_0-bom-wfk-210-redhat1
-   id: spring-3_0-bom-wfk-210-redhat1
+ - &spring-3_0-bom-wfk-21
+   id: spring-3_0-bom-wfk-21
    bom: *spring-3_0-bom-wfk
    version: 2.1.0-redhat-1
    labels: {
-      EAP6RepositoryRequired: true,
+      WFK21RepositoryRequired: true,
    }
 
- - &spring-3_1-bom-wfk-210-redhat1
-   id: spring-3_1-bom-wfk-210-redhat1
+ - &spring-3_1-bom-wfk-21
+   id: spring-3_1-bom-wfk-21
    bom: *spring-3_1-bom-wfk
    version: 2.1.0-redhat-1
    labels: {
-      EAP6RepositoryRequired: true,
+      WFK21RepositoryRequired: true,
    }
     
 ##############################################################################
@@ -973,30 +1119,30 @@ availableRuntimes:
    id: jbosseap600runtime
    name: JBoss EAP 6.0.0
    version: 6.0.0
-   url: https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId=12673&product=appplatform&version=&downloadType=distributions
+   url: https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=appplatform&version=6.0.0
    boms:
     - *jboss-javaee-6_0-300redhat1
     - *jboss-javaee-6_0-web-300redhat1
     - *jboss-javaee-6_0-with-errai-100m11-redhat1
-    - *jboss-javaee-6_0-with-errai-wfk-101-redhat1
+    - *jboss-javaee-6_0-with-errai-wfk-21
     - *jboss-javaee-6_0-with-hibernate-100m11-redhat1
     - *jboss-javaee-6_0-with-hibernate-100m12-redhat1
-    - *jboss-javaee-6_0-with-hibernate-wfk-101-redhat1
-    - *jboss-javaee-6_0-with-hibernate3-wfk-101-redhat1
-    - *jboss-javaee-6_0-with-infinispan-wfk-101-redhat1
-    - *jboss-javaee-6_0-with-logging-wfk-101-redhat1
-    - *jboss-javaee-6_0-with-osgi-wfk-101-redhat1
-    - *jboss-javaee-6_0-with-richfaces-wfk-101-redhat1
-    - *jboss-javaee-6_0-with-security-wfk-101-redhat1
+    - *jboss-javaee-6_0-with-hibernate-wfk-21
+    - *jboss-javaee-6_0-with-hibernate3-wfk-21
+    - *jboss-javaee-6_0-with-infinispan-wfk-21
+    - *jboss-javaee-6_0-with-logging-wfk-21
+    - *jboss-javaee-6_0-with-osgi-wfk-21
+    - *jboss-javaee-6_0-with-richfaces-wfk-21
+    - *jboss-javaee-6_0-with-security-wfk-21
     - *jboss-javaee-6_0-with-tools-100m11-redhat1
     - *jboss-javaee-6_0-with-tools-100m12-redhat1
-    - *jboss-javaee-6_0-with-tools-wfk-101-redhat1
+    - *jboss-javaee-6_0-with-tools-wfk-21
     - *jboss-javaee-6_0-with-transactions-100m11-redhat1
     - *jboss-javaee-6_0-with-transactions-100m12-redhat1
-    - *jboss-javaee-6_0-with-transactions-wfk-101-redhat1
-    - *spring-2_5-bom-wfk-210-redhat1
-    - *spring-3_0-bom-wfk-210-redhat1
-    - *spring-3_1-bom-wfk-210-redhat1
+    - *jboss-javaee-6_0-with-transactions-wfk-21
+    - *spring-2_5-bom-wfk-21
+    - *spring-3_0-bom-wfk-21
+    - *spring-3_1-bom-wfk-21
    defaultBom: *jboss-javaee-6_0-300redhat1
    defaultArchetype: *jboss-javaee6-webapp-archetype-last
    archetypes:
@@ -1018,20 +1164,20 @@ availableRuntimes:
    id: jbosseap601runtime
    name: JBoss EAP 6.0.1
    version: 6.0.1
-   url: https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId=12673&product=appplatform&version=&downloadType=distributions
+   url: https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=appplatform&version=6.0.1
    boms:
-    - *jboss-javaee-6_0-301redhat1
-    - *jboss-javaee-6_0-web-301redhat1
-    - *jboss-javaee-6_0-all-301redhat1
-    - *jboss-javaee-6_0-with-errai-102-redhat1
-    - *jboss-javaee-6_0-with-hibernate-102-redhat1
-    - *jboss-javaee-6_0-with-hibernate3-102-redhat1
-    - *jboss-javaee-6_0-with-logging-102-redhat1
-    - *jboss-javaee-6_0-with-osgi-102-redhat1
-    - *jboss-javaee-6_0-with-security-102-redhat1
-    - *jboss-javaee-6_0-with-tools-102-redhat1
-    - *jboss-javaee-6_0-with-transactions-102-redhat1
-   defaultBom: *jboss-javaee-6_0-300redhat1
+    - *jboss-javaee-6_0-eap601
+    - *jboss-javaee-6_0-web-eap601
+    - *jboss-javaee-6_0-all-eap601
+    - *jboss-javaee-6_0-with-errai-eap601
+    - *jboss-javaee-6_0-with-hibernate-eap601
+    - *jboss-javaee-6_0-with-hibernate3-eap601
+    - *jboss-javaee-6_0-with-logging-eap601
+    - *jboss-javaee-6_0-with-osgi-eap601
+    - *jboss-javaee-6_0-with-security-eap601
+    - *jboss-javaee-6_0-with-tools-eap601
+    - *jboss-javaee-6_0-with-transactions-eap601
+   defaultBom: *jboss-javaee-6_0-web-eap601
    defaultArchetype: *jboss-javaee6-webapp-archetype-last
    archetypes:
     - *jboss-javaee6-webapp-archetype-last
@@ -1047,6 +1193,49 @@ availableRuntimes:
         runtime-type: EAP
    }
    
+   #####################
+   #   E A P 6.1 Alpha #
+   ####################
+
+ - &jbosseap610runtime
+   id: jbosseap610runtime
+   name: JBoss EAP 6.1.0 Alpha-1
+   version: 6.1.0.Alpha1
+   url: https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=appplatform&version=6.1.0+Alpha
+   downloadUrl: http://download.jboss.org/jbosseap/6/jboss-eap-6.1.0.Alpha/jboss-eap-6.1.0.Alpha.zip
+   boms:
+    - *jboss-javaee-6_0-eap61
+    - *jboss-javaee-6_0-web-eap61
+    - *jboss-javaee-6_0-with-all-eap61
+    - *jboss-javaee-6_0-with-deltaspike-eap61
+    - *jboss-javaee-6_0-with-errai-eap61
+    - *jboss-javaee-6_0-with-hibernate-eap61
+    - *jboss-javaee-6_0-with-hibernate3-eap61
+    - *jboss-javaee-6_0-with-infinispan-eap61
+    - *jboss-javaee-6_0-with-logging-eap61
+    - *jboss-javaee-6_0-with-osgi-eap61
+    - *jboss-javaee-6_0-with-resteasy-eap61
+    - *jboss-javaee-6_0-with-richfaces-eap61
+    - *jboss-javaee-6_0-with-security-eap61
+    - *jboss-javaee-6_0-with-tools-eap61
+    - *jboss-javaee-6_0-with-transactions-eap61
+   defaultBom: *jboss-javaee-6_0-eap61
+   defaultArchetype: *jboss-javaee6-webapp-archetype-last
+   archetypes:
+    - *jboss-javaee6-webapp-archetype-last
+    - *jboss-javaee6-webapp-blank-archetype-last
+    - *jboss-javaee6-webapp-ear-archetype-last
+    - *jboss-javaee6-webapp-ear-blank-archetype-last
+    - *jboss-html5-mobile-archetype-last
+    - *jboss-html5-mobile-blank-archetype-last
+    - *richfaces-archetype-kitchensink-423final2
+    - *jboss-errai-kitchensink-archetype-211final  
+   labels: {
+        runtime-category: SERVER,
+        runtime-type: EAP,
+        EarlyAccess: true,
+   }
+
 
    ###############
    #   A S 7.1   #
@@ -1155,6 +1344,11 @@ minorReleases:
    #   E A P  6.X   #
    ##################
    
+ - &jbeap61
+   name: JBoss EAP
+   version: 6.1
+   recommendedRuntime: *jbosseap610runtime
+
  - &jbeap60
    name: JBoss EAP
    version: 6.0
@@ -1193,3 +1387,4 @@ majorReleases:
    recommendedRuntime: *jbosseap601runtime
    minorReleases:
     - *jbeap60
+    - *jbeap61


### PR DESCRIPTION
"Early Access" releases has tag "EarlyAccess" label for its Runtime and BOMs.

Some testes were included to achieve that and also improve the existing tests
