### PR TITLE
JBIDE-15645 : Add new ArchetypeVersion labels for JBoss Central

### DIFF
--- a/stacks.yaml
+++ b/stacks.yaml
@@ -1407,7 +1407,13 @@ availableArchetypeVersions:
    version: *lastEAPArchetypeRelease
    repositoryURL:
    labels: {
-       additionalRepositories:  ["http://maven.repository.redhat.com/techpreview/all/", "http://jboss-developer.github.io/temp-maven-repo/"],
+       additionalRepositories: {
+         "redhat-techpreview-all-repository": "http://maven.repository.redhat.com/techpreview/all/",
+       },
+       essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-tools:pom:6.2.0-build-5", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.2.0-build-5"],
+       type: javaee-web,
+       target: product,
+       environment: web-ee6,
    }
 
  - &jboss-javaee6-webapp-blank-archetype-last-eap
@@ -1416,7 +1422,14 @@ availableArchetypeVersions:
    version: *lastEAPArchetypeRelease
    repositoryURL:
    labels: {
-       additionalRepositories:  ["http://maven.repository.redhat.com/techpreview/all/", "http://jboss-developer.github.io/temp-maven-repo/"],
+       additionalRepositories: {
+         "redhat-techpreview-all-repository": "http://maven.repository.redhat.com/techpreview/all/",
+       },
+       essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-tools:pom:6.2.0-build-5", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.2.0-build-5"],
+       type: javaee-web,
+       target: product,
+       environment: web-ee6,
+       isBlank: true,
    }
 
  - &jboss-javaee6-webapp-ear-archetype-last-eap
@@ -1425,7 +1438,13 @@ availableArchetypeVersions:
    version: *lastEAPArchetypeRelease
    repositoryURL:
    labels: {
-       additionalRepositories:  ["http://maven.repository.redhat.com/techpreview/all/", "http://jboss-developer.github.io/temp-maven-repo/"],
+       additionalRepositories: {
+         "redhat-techpreview-all-repository": "http://maven.repository.redhat.com/techpreview/all/",
+       },
+       essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-tools:pom:6.2.0-build-5", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.2.0-build-5"],
+       type: javaee-ear, 
+       target: product,
+       environment: full-ee6,
    }
 
  - &jboss-javaee6-webapp-ear-blank-archetype-last-eap
@@ -1434,7 +1453,14 @@ availableArchetypeVersions:
    version: *lastEAPArchetypeRelease
    repositoryURL:
    labels: {
-       additionalRepositories:  ["http://maven.repository.redhat.com/techpreview/all/", "http://jboss-developer.github.io/temp-maven-repo/"],
+       additionalRepositories: {
+         "redhat-techpreview-all-repository": "http://maven.repository.redhat.com/techpreview/all/",
+       },
+       essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-tools:pom:6.2.0-build-5", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.2.0-build-5"],
+       type: javaee-ear, 
+       target: product,
+       environment: full-ee6,
+       isBlank: true,
    }
 
  - &jboss-html5-mobile-archetype-last-wfk
@@ -1443,7 +1469,13 @@ availableArchetypeVersions:
    version: *lastWFKArchetypeRelease
    repositoryURL:
    labels: {
-       additionalRepositories:  ["http://maven.repository.redhat.com/techpreview/all/", "http://jboss-developer.github.io/temp-maven-repo/"],
+       additionalRepositories: {
+         "redhat-techpreview-all-repository": "http://maven.repository.redhat.com/techpreview/all/",
+       },
+       essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-tools:pom:6.2.0-build-5", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.2.0-build-5"],
+       type: html5-mobile, 
+       target: product,
+       environment: web-ee6,
    }
 
  - &jboss-html5-mobile-blank-archetype-last-wfk
@@ -1452,7 +1484,14 @@ availableArchetypeVersions:
    version: *lastWFKArchetypeRelease
    repositoryURL:
    labels: {
-       additionalRepositories:  ["http://maven.repository.redhat.com/techpreview/all/", "http://jboss-developer.github.io/temp-maven-repo/"],
+       additionalRepositories: {
+         "redhat-techpreview-all-repository": "http://maven.repository.redhat.com/techpreview/all/",
+       },
+       essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-tools:pom:6.2.0-build-5", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.2.0-build-5"],
+       type: html5-mobile,
+       target: product,
+       environment: web-ee6,
+       isBlank: true,
    }
 
    #######################
@@ -1464,7 +1503,11 @@ availableArchetypeVersions:
    archetype: *jboss-javaee6-webapp-archetype
    version: *lastArchetypeRelease
    repositoryURL:
-   labels: {}
+   labels: {
+       type: javaee-web,
+       target: community,
+       environment: web-ee6,
+   }
 
    ########################################
    #   Java EE 6 Webapp (Blank Skeleton)  #
@@ -1475,7 +1518,12 @@ availableArchetypeVersions:
    archetype: *jboss-javaee6-webapp-blank-archetype
    version: *lastArchetypeRelease
    repositoryURL:
-   labels: {}
+   labels: {
+       type: javaee-web,
+       target: community,
+       environment: web-ee6,
+       isBlank: true,
+   }
 
    ########################################
    #   JBoss AS 7 / Java EE 6 EAR Webapp  #
@@ -1486,7 +1534,11 @@ availableArchetypeVersions:
    archetype: *jboss-javaee6-webapp-ear-archetype
    version: *lastArchetypeRelease
    repositoryURL:
-   labels: {}
+   labels: {
+       type: javaee-ear,
+       target: community,
+       environment: full-ee6,
+   }
 
    ##########################################################
    #   JBoss AS 7 / Java EE 6 EAR Webapp  (Blank Skeleton)  #
@@ -1497,7 +1549,12 @@ availableArchetypeVersions:
    archetype: *jboss-javaee6-webapp-ear-blank-archetype
    version: *lastArchetypeRelease
    repositoryURL:
-   labels: {}
+   labels: {
+       type: javaee-ear,
+       target: community,
+       environment: full-ee6,
+       isBlank: true,
+   }
 
    ###############################################
    #   Java EE 6 HTML5 Mobile Web Application    #
@@ -1508,7 +1565,11 @@ availableArchetypeVersions:
    archetype: *jboss-html5-mobile-archetype
    version: *lastArchetypeRelease
    repositoryURL:
-   labels: {}
+   labels: {
+       type: html5-mobile,
+       target: community,
+       environment: web-ee6,
+   }
 
    ###############################################################
    #   Java EE 6 HTML5 Mobile Web Application  (Blank Skeleton)  #
@@ -1519,7 +1580,12 @@ availableArchetypeVersions:
    archetype: *jboss-html5-mobile-blank-archetype
    version: *lastArchetypeRelease
    repositoryURL:
-   labels: {}
+   labels: {
+       type: html5-mobile,
+       target: community,
+       environment: web-ee6,
+       isBlank: true,
+   }
 
    ####################################################
    #   RichFaces Archetypes Kitchen Sink Application  #
@@ -1530,7 +1596,11 @@ availableArchetypeVersions:
    archetype: *richfaces-archetype-kitchensink
    version: 4.2.3.Final-2
    repositoryURL:
-   labels: {}
+   labels: {
+       type: richfaces-kitchensink,
+       target: community,
+       environment: web-ee6,
+   }
 
    ###########################################
    #   Errai Kitchen Sink Webapp Archetype   #
@@ -1541,7 +1611,11 @@ availableArchetypeVersions:
    archetype: *jboss-errai-kitchensink-archetype
    version: 2.1.1.Final
    repositoryURL:
-   labels: {}
+   labels: {
+       type: errai-kitchensink,
+       target: community,
+       environment: web-ee6,
+   }
 
 ##########################################################################
 #                                                                        #


### PR DESCRIPTION
- type : javaee-web, javaee-ear, html5-mobile, richfaces-kitchensink,
  errai-kitchensink
- isBlank : true if it's a blank archetype
- environment : web-ee6 or full-ee6, depending on the required Java EE
  profile. We'll add web-ee7, full-ee7 for future wildfly archetypes
- target : product or community
- additionalRepositories : changed list to a Map, as we need to have a
  repository key
- essentialDependencies : collection of GAV coordinates of essential
  depenendencies tooling will try to resolve before creating the project.
  If these deps are missing, the repos defined in additionalRepositories
  will be proposed to be added to settings.xml

https://issues.jboss.org/browse/JBIDE-15645

Signed-off-by: Fred Bricon fbricon@gmail.com
