### PR TITLE
JBIDE-16605 JDF-151 - bad wtp-runtime type id for wf

### DIFF
--- a/stacks.yaml
+++ b/stacks.yaml
@@ -2368,7 +2368,7 @@ availableRuntimes:
         requiresLogModule: false,
         pom: "https://github.com/wildfly/wildfly/blob/8.0.0.Final/pom.xml",
         runtime-size: 154598817,
-        wtp-runtime-type: org.jboss.ide.eclipse.as.wildfly.80
+        wtp-runtime-type: org.jboss.ide.eclipse.as.runtime.wildfly.80
     }
 
    #################


### PR DESCRIPTION
The wtp-runtime-type listed for wildfly is not correct. 
