### PR TITLE
add wfk 2.5 archetypes to EAP 6.1.0

### DIFF
--- a/stacks.yaml
+++ b/stacks.yaml
@@ -2406,6 +2406,11 @@ availableRuntimes:
     - *jboss-html5-mobile-archetype-old
     - *jboss-html5-mobile-archetype-wfk-24
  #    - *jboss-html5-mobile-blank-archetype-wfk-24
+    - *richfaces-archetype-simpleapp-wfk-25
+    - *richfaces-archetype-kitchensink-wfk-25
+    - *jboss-spring-mvc-archetype-wfk-25
+    - *jboss-html5-mobile-blank-archetype-wfk-25
+    - *jboss-html5-mobile-archetype-wfk-25
     - *jboss-errai-kitchensink-archetype-232final
    labels: {
         requiresCredentials: true,


### PR DESCRIPTION
In JBDS, all EAP 6.1+ servers have the same runtime type, org.jboss.ide.eclipse.as.runtime.eap.61
In JBoss Central, when we try to lookup archetypes matching an EAP 6.2 runtime, we use the WTP runtimeid, org.jboss.ide.eclipse.as.runtime.eap.61, and find several matching runtimes in stacks (6.1.0 and 6.2.0). We use the first one, 6.1.0, but it 's not configured to use WFK 2.5 archetypes, so they're not displayed in central.

This patch adds the WFK 2.5 archetypes to EAP 6.1.0. In theory, there should be ,o reason why they'd be incompatible
