### PR TITLE
JDF-793 and JBIDE-14783 - prestacks.yaml should not use html license url

### DIFF
--- a/pre-stacks.yaml
+++ b/pre-stacks.yaml
@@ -20,7 +20,7 @@
 
 licenses:
  - &lgpl http://www.gnu.org/copyleft/lesser.txt
- - &lgpl21 http://www.gnu.org/licenses/lgpl-2.1.html
+ - &lgpl21 http://www.gnu.org/licenses/lgpl-2.1.txt
 
    
 ##########################################################################


### PR DESCRIPTION
Ensure txt only license, no html. 
