### PR TITLE
JBIDE-20769 - dv6.2 not showing up in jbt.  jbt has no eap.62 runtime…

### DIFF
--- a/stacks.yaml
+++ b/stacks.yaml
@@ -3435,7 +3435,7 @@ availableRuntimes:
         runtime-type: EAP,
         runtime-size: 193563910,
         file-type: installer-jar,
-        wtp-runtime-type: org.jboss.ide.eclipse.as.runtime.eap.62
+        wtp-runtime-type: org.jboss.ide.eclipse.as.runtime.eap.61
    }
 
 


### PR DESCRIPTION
… type,  eap 6.2 uses eap.61 runtime type
