### PR TITLE
Add WildFly 11.0.0.Final runtime

### DIFF
--- a/stacks.yaml
+++ b/stacks.yaml
@@ -3854,6 +3854,38 @@ availableRuntimes:
         wtp-runtime-type: org.jboss.ide.eclipse.as.runtime.wildfly.100
     }
 
+   #####################
+   #   WildFly  11.0.0 #
+   #####################
+
+ - &wildfly-1100finalruntime
+   id: wildfly-1100finalruntime
+   name: WildFly 11.0.0 Final
+   groupId: org.wildfly
+   artifactId: wildfly-dist
+   version: 11.0.0.Final
+   license: *lgpl
+   url: http://wildfly.org/downloads/
+   downloadUrl: http://download.jboss.org/wildfly/11.0.0.Final/wildfly-11.0.0.Final.zip
+   boms:
+   defaultBom:
+   defaultArchetype: *wildfly-javaee7-webapp-archetype-latest
+   archetypes:
+    - *wildfly-javaee7-webapp-blank-archetype-latest
+    - *wildfly-javaee7-webapp-archetype-latest
+    - *wildfly-javaee7-webapp-ear-blank-archetype-latest
+    - *wildfly-javaee7-webapp-ear-archetype-latest
+    - *wildfly-html5-mobile-blank-archetype-latest
+    - *wildfly-html5-mobile-archetype-latest
+   labels: {
+        runtime-category: SERVER,
+        runtime-type: AS,
+        requiresLogModule: false,
+        pom: "https://github.com/wildfly/wildfly/blob/11.0.0.Final/pom.xml",
+        runtime-size: 159148919,
+        wtp-runtime-type: org.jboss.ide.eclipse.as.runtime.wildfly.110
+    }
+
    #################
    #  J P P  6.1   #
    #################
@@ -4144,6 +4176,15 @@ minorReleases:
    version: 10.1.0.Final
    recommendedRuntime: *wildfly-1010finalruntime
 
+   ################
+   #   WildFly 11 #
+   ################
+
+ - &wildfly1100final
+   name: WildFly
+   version: 11.0.0.Final
+   recommendedRuntime: *wildfly-1100finalruntime
+
    ###############
    #   JPP 6.x   #
    ###############
@@ -4272,6 +4313,16 @@ majorReleases:
    minorReleases:
     - *wildfly1010final
     - *wildfly1000final
+
+   #################
+   #   WildFly 11  #
+   #################
+
+ - name: WildFly
+   version: 11
+   recommendedRuntime: *wildfly-1100finalruntime
+   minorReleases:
+    - *wildfly1100final
 
    ##################
    #   E A P  6     #


### PR DESCRIPTION
I wasn't sure if the `wtp-runtime-type` property should be `wtp-runtime-type: org.jboss.ide.eclipse.as.runtime.wildfly.100` or `wtp-runtime-type: org.jboss.ide.eclipse.as.runtime.wildfly.110`. If it should be `wtp-runtime-type: org.jboss.ide.eclipse.as.runtime.wildfly.110` please let me know and I'll change it.