### PR TITLE
JBIDE-26178 Fix missing commas in yaml files

### DIFF
--- a/pre-stacks.yaml
+++ b/pre-stacks.yaml
@@ -202,7 +202,7 @@ availableRuntimes:
         runtime-category: SERVER,
         runtime-type: AS,
         runtime-size: 181267148,
-        runtime-md5: 81ed7c2c274881963467c11f204eedfc
+        runtime-md5: 81ed7c2c274881963467c11f204eedfc,
         wtp-runtime-type: org.jboss.ide.eclipse.as.runtime.60
    }
 
@@ -221,7 +221,7 @@ availableRuntimes:
         runtime-category: SERVER,
         runtime-type: AS,
         runtime-size: 182762510,
-        runtime-md5: 2264e4d5ba448fa07716008d1452f1e7
+        runtime-md5: 2264e4d5ba448fa07716008d1452f1e7,
         wtp-runtime-type: org.jboss.ide.eclipse.as.runtime.60
    }
 

--- a/stacks.yaml
+++ b/stacks.yaml
@@ -4060,8 +4060,8 @@ availableRuntimes:
         runtime-category: SERVER,
         runtime-type: GateIn,
         runtime-size: 209420675,
-        runtime-md5: f6e9699a8806445c9e3b34aefca5af46
-        wtp-runtime-type: org.jboss.ide.eclipse.as.runtime.71,
+        runtime-md5: f6e9699a8806445c9e3b34aefca5af46,
+        wtp-runtime-type: org.jboss.ide.eclipse.as.runtime.71
     }
 
 


### PR DESCRIPTION
Both pre-stacks.yaml and stacks.yaml were invalid after
last commit because there were a few commas missing.

Signed-off-by: Martin Malina <mmalina@redhat.com>