### PR TITLE
Adding missing Red Hat prefix to cdk 3.11 and 3.10

### DIFF
--- a/minishift.yaml
+++ b/minishift.yaml
@@ -863,7 +863,7 @@ availableRuntimes:
 
  - &cdk3100
    id: cdk3100
-   name: CDK v3.10.0
+   name: Red Hat CDK v3.10.0
    version: 3.10.0
    license: *apache20
    url: https://developers.redhat.com/products/cdk/download/
@@ -887,7 +887,7 @@ availableRuntimes:
 
  - &cdk3110
    id: cdk3110
-   name: CDK v3.11.0
+   name: Red Hat CDK v3.11.0
    version: 3.11.0
    license: *apache20
    url: https://developers.redhat.com/products/cdk/download/


### PR DESCRIPTION
Signed-off-by: Ondrej Dockal <odockal@redhat.com>