### PR TITLE
JDF-884 - replace techpreview to maven redhat ga repository

### DIFF
--- a/src/test/resources/settings-all.xml
+++ b/src/test/resources/settings-all.xml
@@ -34,8 +34,8 @@
                     </snapshots>
                 </repository>
                 <repository>
-                    <id>jboss-all</id>
-                    <url>https://maven.repository.redhat.com/techpreview/all</url>
+                    <id>redhat-ga</id>
+                    <url>https://maven.repository.redhat.com/ga/</url>
                     <releases>
                         <enabled>true</enabled>
                     </releases>
@@ -56,8 +56,8 @@
             </repositories>
             <pluginRepositories>
                 <pluginRepository>
-                    <id>jboss-all-maven-plugin-repository</id>
-                    <url>https://maven.repository.redhat.com/techpreview/all</url>
+                    <id>redhat-ga-plugin-repository</id>
+                    <url>https://maven.repository.redhat.com/ga/</url>
                     <releases>
                         <enabled>true</enabled>
                     </releases>

--- a/stacks.yaml
+++ b/stacks.yaml
@@ -525,7 +525,7 @@ availableBomVersions:
    version: 3.0.0.Final-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -535,7 +535,7 @@ availableBomVersions:
    version: *eap601SpecBomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -545,7 +545,7 @@ availableBomVersions:
    version: *eap610SpecBomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -555,7 +555,7 @@ availableBomVersions:
    version: *eap620SpecBomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -565,7 +565,7 @@ availableBomVersions:
    version: *eap630SpecBomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -575,7 +575,7 @@ availableBomVersions:
    version: *eap640SpecBomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -589,7 +589,7 @@ availableBomVersions:
    version: 3.0.0.Final-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -599,7 +599,7 @@ availableBomVersions:
    version: *eap601SpecBomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -610,7 +610,7 @@ availableBomVersions:
    version: *eap610SpecBomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -620,7 +620,7 @@ availableBomVersions:
    version: *eap620SpecBomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -630,7 +630,7 @@ availableBomVersions:
    version: *eap630SpecBomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -640,7 +640,7 @@ availableBomVersions:
    version: *eap640SpecBomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -655,7 +655,7 @@ availableBomVersions:
    version: *eap610BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -666,7 +666,7 @@ availableBomVersions:
    version: *wfk22BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -677,7 +677,7 @@ availableBomVersions:
    version: *wfk23BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -688,7 +688,7 @@ availableBomVersions:
    version: *wfk24BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -698,7 +698,7 @@ availableBomVersions:
    version: *wfk25BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -709,7 +709,7 @@ availableBomVersions:
    version: *wfk26BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -719,7 +719,7 @@ availableBomVersions:
    version: *wfk27BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -730,7 +730,7 @@ availableBomVersions:
    version: 1.0.0.M11-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -741,7 +741,7 @@ availableBomVersions:
    version: *eap601BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -752,7 +752,7 @@ availableBomVersions:
    version: *eap610BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -763,7 +763,7 @@ availableBomVersions:
    version: *wfk21BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -774,7 +774,7 @@ availableBomVersions:
    version: *wfk22BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -785,7 +785,7 @@ availableBomVersions:
    version: *wfk23BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -795,7 +795,7 @@ availableBomVersions:
    version: *wfk24BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -806,7 +806,7 @@ availableBomVersions:
    version: 1.0.0.M11-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -817,7 +817,7 @@ availableBomVersions:
    version: 1.0.0.M12-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -828,7 +828,7 @@ availableBomVersions:
    version: *eap601BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -839,7 +839,7 @@ availableBomVersions:
    version: *eap610BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -849,7 +849,7 @@ availableBomVersions:
    version: *eap620BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -859,7 +859,7 @@ availableBomVersions:
    version: *eap630BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -869,7 +869,7 @@ availableBomVersions:
    version: *eap640BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -880,7 +880,7 @@ availableBomVersions:
    version: *wfk21BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -891,7 +891,7 @@ availableBomVersions:
    version: *wfk22BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -902,7 +902,7 @@ availableBomVersions:
    version: *wfk23BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -913,7 +913,7 @@ availableBomVersions:
    version: *eap601BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -924,7 +924,7 @@ availableBomVersions:
    version: *eap610BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -934,7 +934,7 @@ availableBomVersions:
    version: *eap620BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -944,7 +944,7 @@ availableBomVersions:
    version: *eap630BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -954,7 +954,7 @@ availableBomVersions:
    version: *eap640BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
  
@@ -965,7 +965,7 @@ availableBomVersions:
    version: *wfk21BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -976,7 +976,7 @@ availableBomVersions:
    version: *wfk24BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -986,7 +986,7 @@ availableBomVersions:
    version: *wfk25BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -997,7 +997,7 @@ availableBomVersions:
    version: *wfk26BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1007,7 +1007,7 @@ availableBomVersions:
    version: *wfk27BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1017,7 +1017,7 @@ availableBomVersions:
    version: *eap610BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1028,7 +1028,7 @@ availableBomVersions:
    version: *wfk21BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1038,7 +1038,7 @@ availableBomVersions:
    version: *eap601BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1048,7 +1048,7 @@ availableBomVersions:
    version: *eap610BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1058,7 +1058,7 @@ availableBomVersions:
    version: *eap620BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1068,7 +1068,7 @@ availableBomVersions:
    version: *eap630BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1078,7 +1078,7 @@ availableBomVersions:
    version: *eap640BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1088,7 +1088,7 @@ availableBomVersions:
    version: *wfk21BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1098,7 +1098,7 @@ availableBomVersions:
    version: *eap601BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1108,7 +1108,7 @@ availableBomVersions:
    version: *eap610BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1118,7 +1118,7 @@ availableBomVersions:
    version: *eap620BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1128,7 +1128,7 @@ availableBomVersions:
    version: *eap630BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1138,7 +1138,7 @@ availableBomVersions:
    version: *eap640BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1148,7 +1148,7 @@ availableBomVersions:
    version: *wfk21BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
  
@@ -1158,7 +1158,7 @@ availableBomVersions:
    version: *eap620BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1168,7 +1168,7 @@ availableBomVersions:
    version: *eap630BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1178,7 +1178,7 @@ availableBomVersions:
    version: *eap640BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1188,7 +1188,7 @@ availableBomVersions:
    version: *wfk21BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1198,7 +1198,7 @@ availableBomVersions:
    version: *wfk22BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1208,7 +1208,7 @@ availableBomVersions:
    version: *wfk23BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1218,7 +1218,7 @@ availableBomVersions:
    version: *wfk24BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1228,7 +1228,7 @@ availableBomVersions:
    version: *wfk25BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1238,7 +1238,7 @@ availableBomVersions:
    version: *wfk26BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1248,7 +1248,7 @@ availableBomVersions:
    version: *wfk27BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1258,7 +1258,7 @@ availableBomVersions:
    version: *eap601BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1268,7 +1268,7 @@ availableBomVersions:
    version: *eap610BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1278,7 +1278,7 @@ availableBomVersions:
    version: *eap620BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1288,7 +1288,7 @@ availableBomVersions:
    version: *eap630BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1298,7 +1298,7 @@ availableBomVersions:
    version: *eap640BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1309,7 +1309,7 @@ availableBomVersions:
    version: *wfk21BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1320,7 +1320,7 @@ availableBomVersions:
    version: *wfk24BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1330,7 +1330,7 @@ availableBomVersions:
    version: *wfk25BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1340,7 +1340,7 @@ availableBomVersions:
    version: *wfk26BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1350,7 +1350,7 @@ availableBomVersions:
    version: *wfk27BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1360,7 +1360,7 @@ availableBomVersions:
    version: *wfk25BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1370,7 +1370,7 @@ availableBomVersions:
    version: *wfk26BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1380,7 +1380,7 @@ availableBomVersions:
    version: *wfk27BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1390,7 +1390,7 @@ availableBomVersions:
    version: *wfk27BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
  
@@ -1400,7 +1400,7 @@ availableBomVersions:
    version: 1.0.0.M11-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1411,7 +1411,7 @@ availableBomVersions:
    version: 1.0.0.M12-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1421,7 +1421,7 @@ availableBomVersions:
    version: *eap601BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1431,7 +1431,7 @@ availableBomVersions:
    version: *eap610BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1441,7 +1441,7 @@ availableBomVersions:
    version: *eap620BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1451,7 +1451,7 @@ availableBomVersions:
    version: *eap630BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1461,7 +1461,7 @@ availableBomVersions:
    version: *eap640BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1471,7 +1471,7 @@ availableBomVersions:
    version: *wfk21BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1481,7 +1481,7 @@ availableBomVersions:
    version: *wfk22BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1492,7 +1492,7 @@ availableBomVersions:
    version: *wfk23BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1503,7 +1503,7 @@ availableBomVersions:
    version: *wfk24BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1513,7 +1513,7 @@ availableBomVersions:
    version: *wfk25BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1523,7 +1523,7 @@ availableBomVersions:
    version: *wfk26BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1533,7 +1533,7 @@ availableBomVersions:
    version: *wfk27BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1544,7 +1544,7 @@ availableBomVersions:
    version: 1.0.0.M11-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1555,7 +1555,7 @@ availableBomVersions:
    version: 1.0.0.M12-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1566,7 +1566,7 @@ availableBomVersions:
    version: *eap601BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1577,7 +1577,7 @@ availableBomVersions:
    version: *eap610BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1587,7 +1587,7 @@ availableBomVersions:
    version: *eap620BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1597,7 +1597,7 @@ availableBomVersions:
    version: *eap630BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1607,7 +1607,7 @@ availableBomVersions:
    version: *eap640BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1617,7 +1617,7 @@ availableBomVersions:
    version: *wfk21BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1653,7 +1653,7 @@ availableBomVersions:
    version: 2.1.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1664,7 +1664,7 @@ availableBomVersions:
    version: 2.2.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
  
@@ -1675,7 +1675,7 @@ availableBomVersions:
    version: 2.3.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1686,7 +1686,7 @@ availableBomVersions:
    version: 2.4.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1696,7 +1696,7 @@ availableBomVersions:
    version: 2.5.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1706,7 +1706,7 @@ availableBomVersions:
    version: 2.6.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1716,7 +1716,7 @@ availableBomVersions:
    version: 2.7.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1726,7 +1726,7 @@ availableBomVersions:
    version: 2.1.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1737,7 +1737,7 @@ availableBomVersions:
    version: 2.2.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1748,7 +1748,7 @@ availableBomVersions:
    version: 2.3.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
  
@@ -1759,7 +1759,7 @@ availableBomVersions:
    version: 2.4.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1770,7 +1770,7 @@ availableBomVersions:
    version: 2.5.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
  - &spring-3_0-bom-wfk-26
@@ -1779,7 +1779,7 @@ availableBomVersions:
    version: 2.6.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1789,7 +1789,7 @@ availableBomVersions:
    version: 2.7.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1799,7 +1799,7 @@ availableBomVersions:
    version: 2.1.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1810,7 +1810,7 @@ availableBomVersions:
    version: 2.2.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1821,7 +1821,7 @@ availableBomVersions:
    version: 2.3.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1832,7 +1832,7 @@ availableBomVersions:
    version: 2.4.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1842,7 +1842,7 @@ availableBomVersions:
    version: 2.5.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1852,7 +1852,7 @@ availableBomVersions:
    version: 2.6.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1862,7 +1862,7 @@ availableBomVersions:
    version: 2.7.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1872,7 +1872,7 @@ availableBomVersions:
    version: 2.2.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1883,7 +1883,7 @@ availableBomVersions:
    version: 2.3.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1894,7 +1894,7 @@ availableBomVersions:
    version: 2.4.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1904,7 +1904,7 @@ availableBomVersions:
    version: 2.5.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1914,7 +1914,7 @@ availableBomVersions:
    version: 2.6.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1924,7 +1924,7 @@ availableBomVersions:
    version: 2.7.0-redhat-1
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1938,7 +1938,7 @@ availableBomVersions:
    version: *eap610BomRelease
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -1953,7 +1953,7 @@ availableBomVersions:
    version: 1.0.3.Final-redhat-2
    labels: {
       additionalRepositories: {
-        "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+        "redhat-ga": "https://maven.repository.redhat.com/ga",
       },
       EarlyAccess: true,
    }
@@ -1964,7 +1964,7 @@ availableBomVersions:
    version: 1.0.0.Final-redhat-2
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
    }
 
@@ -2268,7 +2268,7 @@ availableArchetypeVersions:
    repositoryURL: 
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-tools:pom:6.2.0.GA", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.2.0.GA"],
        type: javaee-web,
@@ -2283,7 +2283,7 @@ availableArchetypeVersions:
    repositoryURL: 
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-tools:pom:6.3.0.GA", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.3.0.GA"],
        type: javaee-web,
@@ -2298,7 +2298,7 @@ availableArchetypeVersions:
    repositoryURL: 
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-tools:pom:6.4.0.GA", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.4.0.GA"],
        type: javaee-web,
@@ -2313,7 +2313,7 @@ availableArchetypeVersions:
    repositoryURL: 
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-tools:pom:6.2.0.GA", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.2.0.GA"],
        type: javaee-web,
@@ -2329,7 +2329,7 @@ availableArchetypeVersions:
    repositoryURL: 
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-tools:pom:6.3.0.GA", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.3.0.GA"],
        type: javaee-web,
@@ -2345,7 +2345,7 @@ availableArchetypeVersions:
    repositoryURL: 
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-tools:pom:6.4.0.GA", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.4.0.GA"],
        type: javaee-web,
@@ -2361,7 +2361,7 @@ availableArchetypeVersions:
    repositoryURL: 
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-tools:pom:6.2.0.GA", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.2.0.GA"],
        type: javaee-ear, 
@@ -2376,7 +2376,7 @@ availableArchetypeVersions:
    repositoryURL: 
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-tools:pom:6.3.0.GA", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.3.0.GA"],
        type: javaee-ear, 
@@ -2391,7 +2391,7 @@ availableArchetypeVersions:
    repositoryURL: 
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-tools:pom:6.4.0.GA", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.4.0.GA"],
        type: javaee-ear, 
@@ -2406,7 +2406,7 @@ availableArchetypeVersions:
    repositoryURL: 
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-tools:pom:6.2.0.GA", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.2.0.GA"],
        type: javaee-ear, 
@@ -2422,7 +2422,7 @@ availableArchetypeVersions:
    repositoryURL: 
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-tools:pom:6.3.0.GA", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.3.0.GA"],
        type: javaee-ear, 
@@ -2438,7 +2438,7 @@ availableArchetypeVersions:
    repositoryURL: 
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-tools:pom:6.4.0.GA", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.4.0.GA"],
        type: javaee-ear, 
@@ -2458,7 +2458,7 @@ availableArchetypeVersions:
    repositoryURL: 
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.wfk:jboss-javaee-6.0-with-tools:pom:2.4.0-redhat-2", "org.jboss.bom:jboss-javaee-6.0-with-hibernate:pom:1.0.4.Final-redhat-9"],
        type: html5-mobile, 
@@ -2473,7 +2473,7 @@ availableArchetypeVersions:
    repositoryURL: 
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.wfk:jboss-javaee-6.0-with-tools:pom:2.5.0-redhat-1", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.2.0.GA"],
        type: html5-mobile, 
@@ -2488,7 +2488,7 @@ availableArchetypeVersions:
    repositoryURL: 
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.wfk:jboss-javaee-6.0-with-tools:pom:2.6.0-redhat-1", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.2.3.GA"],
        type: html5-mobile, 
@@ -2504,7 +2504,7 @@ availableArchetypeVersions:
    repositoryURL: 
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.wfk:jboss-javaee-6.0-with-tools:pom:2.7.0-redhat-1", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.3.2.GA"],
        type: html5-mobile, 
@@ -2519,7 +2519,7 @@ availableArchetypeVersions:
    repositoryURL: 
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.wfk:jboss-javaee-6.0-with-tools:pom:2.5.0-redhat-1", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.2.0.GA"],
        type: html5-mobile, 
@@ -2536,7 +2536,7 @@ availableArchetypeVersions:
    repositoryURL: 
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.wfk:jboss-javaee-6.0-with-tools:pom:2.6.0-redhat-1", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.2.3.GA"],
        type: html5-mobile, 
@@ -2553,7 +2553,7 @@ availableArchetypeVersions:
    repositoryURL: 
    labels: {
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.wfk:jboss-javaee-6.0-with-tools:pom:2.7.0-redhat-1", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.3.2.GA"],
        type: html5-mobile, 
@@ -2587,7 +2587,7 @@ availableArchetypeVersions:
        target: product,
        environment: web-ee6,
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.wfk:jboss-javaee-6.0-with-tools:pom:2.5.0-redhat-1", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.2.0.GA"],
    }
@@ -2602,7 +2602,7 @@ availableArchetypeVersions:
        target: product,
        environment: web-ee6,
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-richfaces:pom:2.5.0-redhat-1"],
    }
@@ -2617,7 +2617,7 @@ availableArchetypeVersions:
        target: product,
        environment: web-ee6,
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.wfk:jboss-javaee-6.0-with-tools:pom:2.6.0-redhat-1", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.2.3.GA"],
    }
@@ -2632,7 +2632,7 @@ availableArchetypeVersions:
        target: product,
        environment: web-ee6,
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-richfaces:pom:2.6.0-redhat-1"],
    }
@@ -2647,7 +2647,7 @@ availableArchetypeVersions:
        target: product,
        environment: web-ee6,
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.wfk:jboss-javaee-6.0-with-tools:pom:2.7.0-redhat-1", "org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.3.2.GA"],
    }
@@ -2662,7 +2662,7 @@ availableArchetypeVersions:
        target: product,
        environment: web-ee6,
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.eap:jboss-javaee-6.0-with-richfaces:pom:2.7.0-redhat-1"],
    }
@@ -2681,7 +2681,7 @@ availableArchetypeVersions:
        target: product,
        environment: web-ee6,
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.wfk:jboss-javaee-6.0-with-spring4:pom:2.5.0-redhat-1","org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.2.0.GA"],
    }
@@ -2696,7 +2696,7 @@ availableArchetypeVersions:
        target: product,
        environment: web-ee6,
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.wfk:jboss-javaee-6.0-with-spring4:pom:2.6.0-redhat-1","org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.2.3.GA"],
    }
@@ -2711,7 +2711,7 @@ availableArchetypeVersions:
        target: product,
        environment: web-ee6,
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom.wfk:jboss-javaee-6.0-with-spring4:pom:2.7.0-redhat-1","org.jboss.bom.eap:jboss-javaee-6.0-with-hibernate:pom:6.3.2.GA"],
    }
@@ -2730,7 +2730,7 @@ availableArchetypeVersions:
        target: community,
        environment: web-ee6,
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom:jboss-javaee-6.0-with-errai:pom:1.0.4.Final-redhat-wfk-2"]
    }
@@ -2749,7 +2749,7 @@ availableArchetypeVersions:
        target: community,
        environment: web-ee6,
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom:jboss-javaee-6.0-with-tools:pom:1.0.4.Final-redhat-4"]
    }
@@ -2765,7 +2765,7 @@ availableArchetypeVersions:
        environment: web-ee6,
        isBlank: true,
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom:jboss-javaee-6.0-with-tools:pom:1.0.4.Final-redhat-4"]
    }
@@ -2780,7 +2780,7 @@ availableArchetypeVersions:
        target: community,
        environment: full-ee6,
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom:jboss-javaee-6.0-with-tools:pom:1.0.4.Final-redhat-4"]
    }
@@ -2796,7 +2796,7 @@ availableArchetypeVersions:
        environment: full-ee6,
        isBlank: true,
        additionalRepositories: {
-         "redhat-techpreview-all-repository": "https://maven.repository.redhat.com/techpreview/all/",
+         "redhat-ga": "https://maven.repository.redhat.com/ga",
        },
        essentialDependencies: ["org.jboss.bom:jboss-javaee-6.0-with-tools:pom:1.0.4.Final-redhat-4"]
    }


### PR DESCRIPTION
as it is seems that the techpreview all is no more online
maybe we should remove copletelyh all references to techpreview especially given that it seems related only to old releases butI guess it can be think about in another iteration. This version allows to unblock situation and have a workaround "main" branch