### PR TITLE
fixed wf27 name and default adapter

### DIFF
--- a/stacks.yaml
+++ b/stacks.yaml
@@ -5060,7 +5060,7 @@ availableRuntimes:
    artifactId: wildfly-dist
    version: 27.0.0.Final
    license: *lgpl
-   downloadUrl: https://github.com/wildfly/wildfly/releases/download/27.0.0.Final/wildfly-preview-27.0.0.Final.zip
+   downloadUrl: https://github.com/wildfly/wildfly/releases/download/27.0.0.Final/wildfly-27.0.0.Final.zip
    url: https://wildfly.org/downloads/
    boms:
    defaultBom:
@@ -5079,7 +5079,7 @@ availableRuntimes:
         pom: "https://github.com/wildfly/wildfly/blob/27.0.0.Final/pom.xml",
         runtime-size: 234182014,
         runtime-md5: 12ee715b7a17c60fd7088a0a18a7f686,
-        wtp-runtime-type: org.jboss.ide.eclipse.as.runtime.wildfly.240
+        wtp-runtime-type: org.jboss.ide.eclipse.as.runtime.wildfly.270
     }
 
    #################


### PR DESCRIPTION
Signed-off-by: Oleksii Korniienko <olkornii@redhat.com>

Download and install is not active. Wf27 is available in wf24+ adapter, but should be in wf27 adapter.
![image](https://user-images.githubusercontent.com/60704619/207851651-d97a5b54-fc21-4f97-9317-4d6ee7e7604c.png)
